### PR TITLE
warn when the Hive table is partitioned

### DIFF
--- a/src/pycodehash/datasets/hive.py
+++ b/src/pycodehash/datasets/hive.py
@@ -25,6 +25,12 @@ class HiveTableHash(ApproximateHasher):
         # DataFrame logging for debugging
         logger.debug("%s", data)
 
+        if not data[data["col_name"] == "# Partition Information"].empty:
+            logger.warning(
+                "The Hive table is partitioned. "
+                "It is recommended to hash each partition to deal with incremental load."
+            )
+
         # Select relevant columns
         data = data[data["col_name"].isin(["Created Time", "Statistics"])]
 


### PR DESCRIPTION
Warn when a Hive table is partioned. In that case, it is probably more efficient to check the hashes of each of the underlying partitions (e.g. use the `FileHasher` on the parquet files).