### PR TITLE
CHG: the `PartitionedApproximateHasher` base class now handles the hashing of partitions

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -53,6 +53,7 @@ _Table 2: Comparison of SHA256 hashing of the full file and fast approximate has
 In the above table, we can see that the larger the dataset gets, the higher speedup ratio is.
 To create an `ApproximateHasher` in `pycodehash`, we only need to code the logic to obtain this metadata as a
 dictionary in the `collect_metadata` method, and the class does the rest.
+The hash of the metadata is invariant to the ordering of the keys.
 
 ## Supported Dataset types
 
@@ -75,5 +76,9 @@ Many datasets consist of collections of objects, or subsets of data:
 
 Hashing these datasets on the object level, allows for only recomputing the parts of the data that have changed.
 For these cases, `pycodehash` has the `PartitionedApproximateHasher` base class.
-It requires an `ApproximateHasher` and implements the `collect_hashes` method.
+It requires an `ApproximateHasher` and implements the `collect_partitions` method.
 Currently, there is an implementation of `LocalDirectoryHash` recursively collects the hashes for each file in that directory.
+Another implementation of the `PartitionedApproximateHasher` is `LocalFilesHash`, which operates on a list of files.
+
+The `PartitionedApproximateHasher` is an `ApproximateHasher` in itself, which means that the `compute_hash` method is supported.
+This hash is invariant to the ordering of the partitions.

--- a/src/pycodehash/datasets/__init__.py
+++ b/src/pycodehash/datasets/__init__.py
@@ -2,4 +2,11 @@
 from pycodehash.datasets.approximate_hasher import ApproximateHasher, PartitionedApproximateHasher
 from pycodehash.datasets.local import LocalDirectoryHash, LocalFileHash, hash_file_full
 
-__all__ = ["LocalFileHash", "LocalDirectoryHash", "ApproximateHasher", "PartitionedApproximateHasher", "hash_file_full"]
+__all__ = [
+    "LocalFileHash",
+    "LocalFileHash",
+    "LocalDirectoryHash",
+    "ApproximateHasher",
+    "PartitionedApproximateHasher",
+    "hash_file_full",
+]

--- a/src/pycodehash/datasets/approximate_hasher.py
+++ b/src/pycodehash/datasets/approximate_hasher.py
@@ -32,9 +32,21 @@ class ApproximateHasher(ABC):
 
 
 class PartitionedApproximateHasher(ApproximateHasher):
+    def __init__(self, hasher: ApproximateHasher):
+        self.hasher = hasher
+
     @abstractmethod
-    def collect_hashes(self, *args, **kwargs) -> dict[str, Any]:
+    def collect_partitions(self, *args, **kwargs) -> list[str]:
         pass
 
+    def _hash_partitions(self, partitions: list[str | list[str]]):
+        return {
+            partition: self.hasher.compute_hash(partition)
+            if not isinstance(partition, list)
+            else self._hash_partitions(partition)
+            for partition in partitions
+        }
+
     def collect_metadata(self, *args, **kwargs) -> dict[str, Any]:
-        return self.collect_hashes(*args, **kwargs)
+        partitions = self.collect_partitions(*args, **kwargs)
+        return self._hash_partitions(partitions)

--- a/src/pycodehash/datasets/local.py
+++ b/src/pycodehash/datasets/local.py
@@ -51,12 +51,19 @@ class LocalFileHash(ApproximateHasher):
 
 class LocalDirectoryHash(PartitionedApproximateHasher):
     def __init__(self):
-        self.hasher = LocalFileHash()
+        super().__init__(LocalFileHash())
 
-    def collect_hashes(self, path: Path) -> dict[str, Any]:
-        return {
-            str(file_path): self.hasher.compute_hash(file_path)
-            if file_path.is_file()
-            else self.collect_hashes(file_path)
+    def collect_partitions(self, path: Path) -> list[str]:
+        return [
+            str(file_path) if file_path.is_file() else self.collect_partitions(file_path)
             for file_path in path.rglob("*")
-        }
+        ]
+
+
+class LocalFilesHash(PartitionedApproximateHasher):
+    def __init__(self):
+        super().__init__(LocalFileHash())
+
+    @staticmethod
+    def collect_partitions(files: list[str]) -> list[str]:
+        return files

--- a/tests/datasets/test_local.py
+++ b/tests/datasets/test_local.py
@@ -48,7 +48,10 @@ def test_approximate_hasher_local_file(local_dataset):
 
 def test_approximate_hasher_local_directory(local_dataset_directory):
     hasher = LocalDirectoryHash()
-    initial_metadata = hasher.collect_hashes(local_dataset_directory)
+    partitions = hasher.collect_partitions(local_dataset_directory)
+    assert len(partitions) == 3
+
+    initial_metadata = hasher.collect_metadata(local_dataset_directory)
     assert isinstance(initial_metadata, dict)
     assert len(initial_metadata.keys()) == 3
 


### PR DESCRIPTION
Subclasses now only need an `ApproximateHasher` instance and to return the partition names

Depends on https://github.com/pycodehash/pycodehash/pull/30