### PR TITLE
ENH: Add functionality to hash Python dependencies through their version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Learn more on how PyCodeHash detects changes in:
 - [Python Functions](https://pycodehash.github.io/pycodehash/python_functions/)
 - [SQL Queries](https://pycodehash.github.io/pycodehash/sql_queries/)
 - [Datasets](https://pycodehash.github.io/pycodehash/datasets/): Files, Directories, S3, Hive
+- [Python dependencies](https://pycodehash.github.io/pycodehash/dependencies/)
 
 ## Installation
 
@@ -85,7 +86,7 @@ print(hasher.hash_file(query_2_file))
 ```
 _[SQL Usage Example](https://github.com/pycodehash/pycodehash/blob/main/example_sql.py)_
 
-## Datasets
+### Datasets
 
 Hash data, such as files, directories, database tables:
 
@@ -112,6 +113,30 @@ print(len(dh.collect_partitions(Path(__file__).parent / "src")))
 # 29
 ```
 _[Dataset Usage Example](https://github.com/pycodehash/pycodehash/blob/main/example_data.py)_
+
+
+### Python Package Dependencies
+
+Hash a user-provided list of Python packages your code depends on. This may be a selection of the total list of dependencies.
+For example the most important libraries your code depends on, that you want to track in order to trigger a rerun of your pipeline in case of version changes.
+The hasher retrieves the installed package versions and creates a hash of those. We emphasize it is up to the user to provide the list of relevant dependencies.
+
+```python
+from pycodehash.dependency import PythonDependencyHash
+
+# hash a list of dependencies
+hasher = PythonDependencyHash()
+
+print(hasher.collect_metadata(dependencies=["pycodehash", "rope"], add_python_version=True))
+# hasher retrieves the installed package versions found
+# {'pycodehash': '0.2.0', 'rope': '1.11.0', 'Python': '3.11'}
+
+print(hasher.compute_hash(dependencies=["pycodehash", "rope"], add_python_version=True))
+# cecb8036ad61235c2577db9943f519b824f7a25e449da9cd332bc600fb5dccf0
+```
+_[Dependency Usage Example](https://github.com/pycodehash/pycodehash/blob/main/example_dependency.py)_
+
+
 
 ## License
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,46 @@
+# Detecting version changes in relevant Python packages
+
+`pycodehash` provides some functionality to hash, and thus keep track of,
+the version numbers of the Python packages most relevant to your pipeline or framework.
+
+We emphasize it is up to the user to provide the list of relevant package dependencies.
+This list may be different per executed function or node in a pipeline, 
+and clearly this may be a selection of the total list of Python dependencies.
+For example, provide the most important libraries your code depends on, 
+and that you want to track in order to trigger a rerun of your pipeline in case of package version changes.
+
+
+The class `PythonDependencyHash` hashes a user-provided list of Python packages. 
+The hasher retrieves the installed package versions and creates a hash of those. 
+Optionally the Python version can be included in the hash.
+
+
+```python
+from pycodehash.dependency import PythonDependencyHash
+
+# hash a list of dependencies
+hasher = PythonDependencyHash()
+
+print(hasher.collect_metadata(dependencies=["pycodehash", "rope"], add_python_version=True))
+# hasher retrieves the installed package versions found
+# {'pycodehash': '0.2.0', 'rope': '1.11.0', 'Python': '3.11'}
+
+print(hasher.compute_hash(dependencies=["pycodehash", "rope"], add_python_version=True))
+# cecb8036ad61235c2577db9943f519b824f7a25e449da9cd332bc600fb5dccf0
+```
+
+Alternatively, one may wish to track all Python packages installed in 
+ones environment. 
+In that case call `pip freeze > requirements_freeze.txt` and then make a hash of the file `requirements_freeze.txt`, 
+as detailed below.
+
+```python
+from pycodehash.datasets import LocalFileHash
+
+# Hash a single file
+fh = LocalFileHash()
+
+hash = fh.compute_hash("requirements_freeze.txt"))
+```
+
+Comparing this hash with a previous hash allows one to keep track of all changing versions in the total list of installed packages.

--- a/example_dependency.py
+++ b/example_dependency.py
@@ -1,0 +1,11 @@
+from pycodehash.dependency import PythonDependencyHash
+
+# hash a list of dependencies
+hasher = PythonDependencyHash()
+
+print(hasher.collect_metadata(dependencies=["pycodehash", "rope"], add_python_version=True))
+# hasher retrieves the installed package versions found
+# {'pycodehash': '0.2.0', 'rope': '1.11.0', 'Python': '3.11'}
+
+print(hasher.compute_hash(dependencies=["pycodehash", "rope"], add_python_version=True))
+# cecb8036ad61235c2577db9943f519b824f7a25e449da9cd332bc600fb5dccf0

--- a/src/pycodehash/dependency/__init__.py
+++ b/src/pycodehash/dependency/__init__.py
@@ -1,0 +1,3 @@
+from pycodehash.dependency.dependency import PythonDependencyHash
+
+__all__ = ["PythonDependencyHash"]

--- a/src/pycodehash/dependency/dependency.py
+++ b/src/pycodehash/dependency/dependency.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import sys
+from importlib.metadata import version
+
+from pycodehash.datasets.approximate_hasher import ApproximateHasher
+
+
+class PythonDependencyHash(ApproximateHasher):
+    """Get the hash of a list of user-provided dependencies"""
+
+    @staticmethod
+    def collect_metadata(dependencies: list[str], add_python_version: bool = False) -> dict[str, str]:
+        """Collect versions of list of provided dependency packages
+
+        Args:
+            dependencies: list of provided dependency packages. Eg. ["numpy", "pandas"]
+            add_python_version: if true, add major.minor python version to output dictionary.
+
+        Returns:
+            Dictionary with dependency packages and their installed versions.
+        """
+        for dep in dependencies:
+            if dep not in sys.modules:
+                msg = f'No module named "{dep}"'
+                raise ModuleNotFoundError(msg)
+        metadata = {dep: version(dep) for dep in sorted(dependencies)}
+
+        if add_python_version:
+            metadata["Python"] = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+        return metadata

--- a/tests/dependency/test_dependency.py
+++ b/tests/dependency/test_dependency.py
@@ -1,0 +1,20 @@
+import sys
+
+import pycodehash
+from pycodehash.datasets.approximate_hasher import inline_metadata
+from pycodehash.dependency import PythonDependencyHash
+from pycodehash.hashing import hash_string
+
+
+def test_dependency():
+    expect = {"pycodehash": pycodehash.__version__, "Python": f"{sys.version_info.major}.{sys.version_info.minor}"}
+    inlined_expect = inline_metadata(expect)
+    expect_hash = hash_string(inlined_expect)
+
+    hasher = PythonDependencyHash()
+
+    result = hasher.collect_metadata(dependencies=["pycodehash"], add_python_version=True)
+    assert result == expect
+
+    result_hash = hasher.compute_hash(dependencies=["pycodehash"], add_python_version=True)
+    assert result_hash == expect_hash


### PR DESCRIPTION
ENH: Add functionality to hash Python dependencies through their version
    
- new class to PythonDependencyHash
- added related unit tests
- update of readme with dependency hash example
- Added documentation on Python package dependencies