### PR TITLE
ENH: visitors for SQL enriched table references

### DIFF
--- a/src/pycodehash/sql/__init__.py
+++ b/src/pycodehash/sql/__init__.py
@@ -1,0 +1,11 @@
+from pycodehash.sql.references import EnrichedTableReferenceVisitor, TableReferenceVisitor, extract_table_references
+from pycodehash.sql.sql_hasher import SQLHasher
+from pycodehash.sql.whitespace_filter import WhitespaceFilter
+
+__all__ = [
+    "TableReferenceVisitor",
+    "EnrichedTableReferenceVisitor",
+    "extract_table_references",
+    "SQLHasher",
+    "WhitespaceFilter",
+]

--- a/src/pycodehash/sql/ast_visitor.py
+++ b/src/pycodehash/sql/ast_visitor.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class ASTVisitor:
+    # based on Pythons AST visitor:
+    # https://github.com/python/cpython/blob/3.12/Lib/ast.py#L383
+    def visit(self, key: str, node: dict[str, Any]):
+        method = "visit_" + key
+        visitor = getattr(self, method, self.generic_visit)
+        return visitor(node)
+
+    def generic_visit(self, node: dict[str, Any]):
+        """Called if no explicit visitor function exists for a node."""
+        items = node if isinstance(node, list) else [node]
+
+        for item in items:
+            for field, value in item.items():
+                if isinstance(value, (list, dict)):
+                    self.visit(field, value)


### PR DESCRIPTION
Determines for each table reference if it originates from a create (output) or from (input) clause

```
Name                                                    Stmts   Miss  Cover
---------------------------------------------------------------------------
src/pycodehash/__init__.py                                  4      0   100%
src/pycodehash/datasets/__init__.py                         3      0   100%
src/pycodehash/datasets/approximate_hasher.py              24      1    96%
src/pycodehash/datasets/hive.py                            21      4    81%
src/pycodehash/datasets/local.py                           37      4    89%
src/pycodehash/datasets/python.py                          32      0   100%
src/pycodehash/datasets/s3.py                              26      2    92%
src/pycodehash/hashing.py                                  53      0   100%
src/pycodehash/preprocessing/__init__.py                    6      0   100%
src/pycodehash/preprocessing/decorator_stripper.py         16      9    44%
src/pycodehash/preprocessing/docstring_stripper.py         15      0   100%
src/pycodehash/preprocessing/function_stripper.py           7      0   100%
src/pycodehash/preprocessing/lines_transformer.py           2      0   100%
src/pycodehash/preprocessing/typehint_stripper.py          15      0   100%
src/pycodehash/preprocessing/whitespace_normalizer.py       7      0   100%
src/pycodehash/python_module/__init__.py                    0      0   100%
src/pycodehash/python_module/import_visitor.py             15      2    87%
src/pycodehash/python_module/python_module_hasher.py       62      4    94%
src/pycodehash/sql/__init__.py                              4      0   100%
src/pycodehash/sql/ast_transformer.py                       2      0   100%
src/pycodehash/sql/ast_visitor.py                          13      0   100%
src/pycodehash/sql/references.py                           34      2    94%
src/pycodehash/sql/sql_hasher.py                           23      0   100%
src/pycodehash/sql/whitespace_filter.py                    21      3    86%
src/pycodehash/stores.py                                   86      6    93%
src/pycodehash/tracing.py                                  89      4    96%
src/pycodehash/transfomers.py                              39      0   100%
src/pycodehash/unparse.py                                   6      2    67%
src/pycodehash/utils.py                                     7      0   100%
src/pycodehash/version.py                                   1      0   100%
---------------------------------------------------------------------------
TOTAL                                                     670     43    94%
```