### PR TITLE
TYP: Typing mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,10 @@ repos:
       exclude: tests/resources/|playgrounds/
     - id: ruff-format
       exclude: tests/resources/|playgrounds/
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.7.1
+  hooks:
+  -   id: mypy
+      args: [ --ignore-missing-imports ]
+      files: "src/"
+      exclude: tests/resources/

--- a/src/pycodehash/datasets/approximate_hasher.py
+++ b/src/pycodehash/datasets/approximate_hasher.py
@@ -21,7 +21,7 @@ class ApproximateHasher(ABC):
     is workable for caching in practice
     """
 
-    METADATA = None
+    METADATA: list[str] | None = None
 
     @abstractmethod
     def collect_metadata(self, *args, **kwargs) -> dict[str, Any]:
@@ -42,7 +42,7 @@ class PartitionedApproximateHasher(ApproximateHasher):
         self.hasher = hasher
 
     @abstractmethod
-    def collect_partitions(self, *args, **kwargs) -> list[str] | dict[str]:
+    def collect_partitions(self, *args, **kwargs) -> list[str] | dict[str, str]:
         """Collect partitions (key, value) or list of keys for hashing"""
 
     def _hash_partitions(self, partitions: list[str] | dict[str, Any]):

--- a/src/pycodehash/datasets/local.py
+++ b/src/pycodehash/datasets/local.py
@@ -45,8 +45,7 @@ class LocalFileHash(ApproximateHasher):
             msg = "Directories not supported. Please use `LocalDirectoryHash`"
             raise TypeError(msg)
 
-        last_modified = path.stat().st_mtime
-        last_modified = datetime.fromtimestamp(last_modified)
+        last_modified = datetime.fromtimestamp(path.stat().st_mtime)
         file_size = path.stat().st_size
 
         return {"last_modified": last_modified, "size": file_size}
@@ -59,7 +58,7 @@ class LocalDirectoryHash(PartitionedApproximateHasher):
         super().__init__(LocalFileHash())
 
     @staticmethod
-    def collect_partitions(path: Path) -> dict[str]:
+    def collect_partitions(path: Path) -> dict[str, str]:
         return {
             str(file_path.relative_to(path)): str(file_path) for file_path in path.rglob("*") if file_path.is_file()
         }
@@ -70,5 +69,5 @@ class LocalFilesHash(PartitionedApproximateHasher):
         super().__init__(LocalFileHash())
 
     @staticmethod
-    def collect_partitions(files: list[str] | dict[str]) -> list[str] | dict[str]:
+    def collect_partitions(files: list[str] | dict[str, str]) -> list[str] | dict[str, str]:
         return files

--- a/src/pycodehash/datasets/python.py
+++ b/src/pycodehash/datasets/python.py
@@ -28,25 +28,21 @@ class PythonFileHash(ApproximateHasher):
         """Read PYC from PEP: https://peps.python.org/pep-0552/
         Based on https://stackoverflow.com/questions/11141387/given-a-python-pyc-file-is-there-a-tool-that-let-me-view-the-bytecode
         """
-        cache_file = Path(importlib.util.cache_from_source(path))
+        cache_file = Path(importlib.util.cache_from_source(str(path)))
         if not cache_file.exists():
-            compile(path, invalidation_mode=self.invalidation_mode)
+            compile(str(path), invalidation_mode=self.invalidation_mode)
 
         hash_str = None
         timestamp = None
         size = None
         with cache_file.open("rb") as file:
-            magic = file.read(4)
-            magic = hexlify(magic).decode("utf-8")
+            magic = hexlify(file.read(4)).decode("utf-8")
 
             bit_field = int.from_bytes(file.read(4), byteorder=sys.byteorder)
             if bit_field & 1 == 1:
-                hash_str = file.read(8)
-                hash_str = hexlify(hash_str).decode("utf-8")
+                hash_str = hexlify(file.read(8)).decode("utf-8")
             else:
-                timestamp = file.read(4)
-                timestamp = asctime(localtime(unpack("I", timestamp)[0]))
-                size = file.read(4)
-                size = unpack("I", size)[0]
+                timestamp = asctime(localtime(unpack("I", file.read(4))[0]))
+                size = unpack("I", file.read(4))[0]
 
         return {"magic": magic, "timestamp": timestamp, "size": size, "hash": hash_str, "bit_field": bit_field}

--- a/src/pycodehash/sql/ast_transformer.py
+++ b/src/pycodehash/sql/ast_transformer.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import Any
 
 
 class ASTTransformer(ABC):
     """Base class for transforming based on the AST"""
 
     @abstractmethod
-    def transform(self, src: str) -> str:
+    def transform(self, src: dict[str, Any]) -> dict[str, Any]:
         pass

--- a/src/pycodehash/sql/ast_visitor.py
+++ b/src/pycodehash/sql/ast_visitor.py
@@ -6,12 +6,12 @@ from typing import Any
 class ASTVisitor:
     # based on Pythons AST visitor:
     # https://github.com/python/cpython/blob/3.12/Lib/ast.py#L383
-    def visit(self, key: str, node: dict[str, Any]):
+    def visit(self, key: str, node: dict[str, Any] | list[dict[str, Any]]):
         method = "visit_" + key
         visitor = getattr(self, method, self.generic_visit)
         return visitor(node)
 
-    def generic_visit(self, node: dict[str, Any]):
+    def generic_visit(self, node: dict[str, Any] | list[dict[str, Any]]):
         """Called if no explicit visitor function exists for a node."""
         items = node if isinstance(node, list) else [node]
 

--- a/src/pycodehash/sql/whitespace_filter.py
+++ b/src/pycodehash/sql/whitespace_filter.py
@@ -31,6 +31,6 @@ class WhitespaceFilter(ASTTransformer):
             # SQLFluff parses clauses with non-unique dict keys (e.g. newline) as a list of dicts
             # When after stripping whitespace and newlines the keys are distinct, we should try to flatten
             if _should_flatten(data):
-                data = _flatten(data)
+                data = _flatten(data)  # type: ignore[assignment]
             return data
         return node

--- a/src/pycodehash/stores.py
+++ b/src/pycodehash/stores.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from importlib.util import find_spec
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Iterable
+from typing import TYPE_CHECKING, Callable, Iterator
 
 import asttokens
 from rope.base.libutils import analyze_modules
@@ -156,11 +156,14 @@ class ProjectStore:
     def get_or_create_for_func(self, func: Callable) -> Project:
         # get the module from the function
         module = inspect.getmodule(func)
+        if module is None:
+            msg = "Module for function not found"
+            raise ValueError(msg)
         name = module.__name__
         pkg, _, _ = name.partition(".")
         if pkg not in self.store:
             self._initialize_project(pkg)
         return self.__getitem__(pkg)
 
-    def __iter__(self) -> Iterable[Project]:
+    def __iter__(self) -> Iterator[Project]:
         yield from self.store.values()

--- a/src/pycodehash/tracing.py
+++ b/src/pycodehash/tracing.py
@@ -119,7 +119,7 @@ def get_func_call_location(node: ast.Call, project: Project, mview: ModuleView) 
     if isinstance(pyname, (ImportedName, ImportedModule)):
         # we assume that as this is an ImportedModule that the node has an ast.Attribute
         # as func rather than an ast.Name
-        name = node.func.attr if isinstance(pyname, ImportedModule) else pyname.imported_name
+        name = node.func.attr if isinstance(pyname, ImportedModule) else pyname.imported_name  # type: ignore[attr-defined]
         finder = occurrences.Finder(project, name, [check_func_definition])
         for occurrence in finder.find_occurrences(pymodule=module):
             location = Location(occurrence)
@@ -157,7 +157,7 @@ def get_func_def_location(func: Callable, project: Project) -> Location | None:
     return None
 
 
-def find_call_definition(node: ast.expr, module: ModuleView, project: Project) -> Location | None:
+def find_call_definition(node: ast.Call, module: ModuleView, project: Project) -> Location | None:
     loc = get_func_call_location(node, project, module)
     if loc is None:
         return None

--- a/src/pycodehash/transfomers.py
+++ b/src/pycodehash/transfomers.py
@@ -29,7 +29,7 @@ class HashCallNameTransformer(NodeTransformer):
                 self.project = project
                 break
         self.module: ModuleView = self.hasher.module_store[module]
-        self.hash_repr = None
+        self.hash_repr: str | None = None
 
     def visit_Call(self, node: ast.Call):
         """Find the hash each call"""

--- a/src/pycodehash/utils.py
+++ b/src/pycodehash/utils.py
@@ -11,5 +11,5 @@ def get_func_name(func: FunctionType, default: str = "<unnamed>") -> str:
     return getattr(func, "__name__", default)
 
 
-def contains_call(node: ast.Expr):
+def contains_call(node: ast.expr) -> bool:
     return any(isinstance(child, ast.Call) for child in ast.walk(node))


### PR DESCRIPTION
Make mypy happy. Without the `--strict` argument, it only complains about errors, but not about missing return types etc.